### PR TITLE
rename factorygirl

### DIFF
--- a/spec/factories/iso.rb
+++ b/spec/factories/iso.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 require 'virtfs/block_io'
 require 'virt_disk/block_file'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :iso, class: OpenStruct do
     path '/var/lib/oz/isos/Fedora22x86_64-url.iso'
     fs { VirtFS::ISO9660::FS.new(VirtFS::BlockIO.new(VirtDisk::BlockFile.new(path))) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,10 +9,10 @@ RSpec.configure do |config|
     c.syntax = [:should, :expect]
   end
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
-    FactoryGirl.find_definitions
+    FactoryBot.find_definitions
   end
 
 end


### PR DESCRIPTION
this is the last external reference we have, after this we can remove the core alias

thanks @Fryguy 